### PR TITLE
dollarValue can be null in api response from Contact Energy

### DIFF
--- a/contact_energy_nz/usage_datum.py
+++ b/contact_energy_nz/usage_datum.py
@@ -12,7 +12,12 @@ class UsageDatum:
             json_item["date"], "%Y-%m-%dT%H:%M:%S.%f%z"
         )
         self.value = float(json_item["value"])
-        self.dollar_value = float(json_item["dollarValue"])
+
+        try:
+            self.dollar_value = float(json_item["dollarValue"])
+        except (TypeError, ValueError):
+            self.dollar_value = None
+
         try:
             self.offpeak_value = float(json_item["offpeakValue"])
         except (TypeError, ValueError):


### PR DESCRIPTION
Here is an example of the api response I got when querying via postman

```json
[
    {
        "currency": "NZD",
        "year": 2023,
        "month": 10,
        "day": 1,
        "hour": 0,
        "date": "2023-10-01T00:00:00.000+13:00",
        "value": "787.200",
        "dollarValue": null,
        "offpeakValue": "0",
        "unchargedValue": "0",
        "offpeakDollarValue": null,
        "unit": "kWh",
        "timeZone": "Pacific/Auckland",
        "percentage": 100
    }
]
```