### PR TITLE
make get_token throw AuthException when appropriate, write test

### DIFF
--- a/contact_energy_nz/contact_energy_api.py
+++ b/contact_energy_nz/contact_energy_api.py
@@ -50,9 +50,9 @@ class ContactEnergyApi:
             ) as response:
                 try:
                     response_json = await response.json()
-                    self.token = response_json.get("token", "")
+                    self.token = response_json["token"]
                     return self.token
-                except AttributeError as e:
+                except KeyError as e:
                     raise AuthException(f"Error accessing JSON fields: {e}")
 
     def _set_headers(self) -> dict[str, str]:
@@ -87,6 +87,7 @@ class ContactEnergyApi:
         """Helper method to query account summary and determine account/contract id"""
         accounts = await self._try_fetch_data(f"{API_BASE_URL}/accounts/v2?ba=")
         account_summary = accounts.get("accountsSummary", [])
+        _LOGGER.debug(account_summary)
         if not account_summary:
             raise ValueError("No account_summary found in API response")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,16 +3,23 @@ import datetime
 import os
 import pytest
 import pytest_asyncio
-from contact_energy_nz import ContactEnergyApi
+from contact_energy_nz import ContactEnergyApi, AuthException
 from dotenv import load_dotenv
+import logging
 
 load_dotenv()
+_LOGGER = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session")
 def event_loop():
     loop = asyncio.get_event_loop()
     yield loop
     loop.close()
+
+@pytest.mark.asyncio
+async def test_authentication_fails(api_client):
+    with pytest.raises(AuthException) as _:
+        api = await ContactEnergyApi.from_credentials(os.environ["CONTACT_USERNAME"], "invalid password")
 
 @pytest_asyncio.fixture(scope="session")
 async def api_client() -> ContactEnergyApi: 


### PR DESCRIPTION
This makes get_token() throw AuthException when there is no token filed in the JSON response.
There is a corresponding test to check whether this functionality works.
Fixes #8 